### PR TITLE
fix: always copy textEndDelimiter from textDelimiter

### DIFF
--- a/lib/list_to_csv_converter.dart
+++ b/lib/list_to_csv_converter.dart
@@ -190,7 +190,10 @@ class ListToCsvConverter extends Converter<List<List>, String>
     if (rowValues == null || rowValues.isEmpty) return '';
 
     fieldDelimiter ??= this.fieldDelimiter;
+    // assign given textDelimiter to textEndDelimiter
+    textEndDelimiter ??= textDelimiter;
     textDelimiter ??= this.textDelimiter;
+    // if textDelimiter was null use the default textEndDelimiter
     textEndDelimiter ??= this.textEndDelimiter;
     eol ??= this.eol;
 

--- a/test/list_to_csv_test.dart
+++ b/test/list_to_csv_test.dart
@@ -186,4 +186,10 @@ main() {
         multipleRowsStream.transform(commaDoubleQuotListToCsvConverter).join();
     expect(f_csv, completion(result));
   });
+
+  test('Issue 5. Quote correctly', () {
+    var csv =
+        const ListToCsvConverter().convert(testDataIssue5, textDelimiter: '#');
+    expect(csv, equals(testCsvIssue5));
+  });
 }

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -12,6 +12,14 @@ const List<dynamic> singleRow = const [
   "g',h",
   5.6
 ];
+
+// see https://github.com/close2/csv/issues/5
+const List<List> testDataIssue5 = const [
+  const ['Alice', 'Austria', 1],
+  const ['Bob', ',Brazil', 2]
+];
+const testCsvIssue5 = 'Alice,Austria,1\r\nBob,#,Brazil#,2';
+
 const String csvSingleRowComma = '1,a,2,aabb,"c\nd",3,"e"",f",4,"g\',h",5.6';
 const String csvSingleRowSemicolon = '1;a;2;aabb;"c\nd";3;"e"",f";4;g\',h;5.6';
 const String csvSingleRowDotDoubleQuot =


### PR DESCRIPTION
if textDelimiter is given and textEndDelimiter is not.

You may override those values directly in the convert function.
Previously we used the textEndDelimiter from the class.

fixes #5