### PR TITLE
Fix type parameters for Dart 1.22.0

### DIFF
--- a/lib/csv_to_list_converter.dart
+++ b/lib/csv_to_list_converter.dart
@@ -6,7 +6,7 @@ part of csv;
 ///
 /// See the [CsvParser] for more information.
 class CsvToListConverter extends Converter<String, List<List>>
-    implements StreamTransformer {
+    implements StreamTransformer<String, List<List>> {
   /// The separator between fields.
   final String fieldDelimiter;
 

--- a/lib/list_to_csv_converter.dart
+++ b/lib/list_to_csv_converter.dart
@@ -72,7 +72,7 @@ part of csv;
 ///
 ///     "aaa","b""bb","ccc"
 class ListToCsvConverter extends Converter<List<List>, String>
-    implements StreamTransformer {
+    implements StreamTransformer<List<List>, String> {
   /// The separator between fields in the outputString.
   final String fieldDelimiter;
 
@@ -170,8 +170,8 @@ class ListToCsvConverter extends Converter<List<List>, String>
   /// [outputSink] must be of type Sink<String>.  (Strong mode prevents us from
   /// specifying the type here.)
   @override
-  List2CsvSink startChunkedConversion(Sink outputSink) {
-    return new List2CsvSink(this, outputSink as Sink<String>);
+  List2CsvSink startChunkedConversion(Sink<String> outputSink) {
+    return new List2CsvSink(this, outputSink);
   }
 
   /// Converts a list of values representing a row into a value separated
@@ -265,7 +265,7 @@ class ListToCsvConverter extends Converter<List<List>, String>
 ///
 /// A single row represented by a [List] may be [add]ed an
 /// the conversion is added to the output sink.
-class List2CsvSink extends ChunkedConversionSink<List> {
+class List2CsvSink extends ChunkedConversionSink<List<List>> {
   /// The List2CsvConverter which has the configurations (fieldDelimiter,
   /// textDel., eol)
   final ListToCsvConverter _converter;


### PR DESCRIPTION
The upgrade to Dart 1.22 introduced some type errors. I think this should resolve them. I've run the tests back to SDK 1.13.0 (the oldest I happen to have available in my Homebrew cache). I don't think this should require more than a patch release.

This should resolve #13.