### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ crashlytics-build.properties
 build/
 packages
 .packages
+.dart_tool/
 
 # Or the files created by dart2js.
 *.dart.js

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ homepage: https://github.com/close2/csv
 documentation: https://github.com/close2/csv
 
 environment:
-  sdk: '>=2.0.0-dev.0.0 <2.1.0'
+  sdk: ^2.0.0
 
 dev_dependencies:
-  test: '>=0.12.8 <0.13.0'
+  test: ^1.0.0


### PR DESCRIPTION
Allow newer versions of the Dart SDK since they shouldn't be breaking at
this point. Also update to a newer, but still wide, version of the test
package.