### PR TITLE
fixes #34: improve performance by avoiding flushing the StringBuffer each row

### DIFF
--- a/lib/list_to_csv_converter.dart
+++ b/lib/list_to_csv_converter.dart
@@ -147,7 +147,8 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
           textDelimiter: textDelimiter,
           textEndDelimiter: textEndDelimiter,
           eol: eol,
-          delimitAllFields: delimitAllFields);
+          delimitAllFields: delimitAllFields,
+          returnString: false);
     });
     return sb.toString();
   }
@@ -188,12 +189,17 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
   /// If in such a case the value also contains [textDelimiter] those
   /// [textDelimiter] instances are doubled (see _Definition of the CSV
   /// Format_ Rule 7 [rfc4180](http://tools.ietf.org/html/rfc4180)).
+  ///
+  /// If [returnString] is true (default), returns the converted String.
+  /// Otherwise output is only written to provided StringBuffer [sb].  Set to
+  /// false to improve performance.
   String convertSingleRow(StringBuffer sb, List rowValues,
       {String fieldDelimiter,
       String textDelimiter,
       String textEndDelimiter,
       String eol,
-      bool delimitAllFields}) {
+      bool delimitAllFields,
+      bool returnString = true}) {
     if (rowValues == null || rowValues.isEmpty) return '';
 
     fieldDelimiter ??= this.fieldDelimiter;
@@ -246,7 +252,7 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
       return sb;
     });
 
-    return sb.toString();
+    return returnString ? sb.toString() : null;
   }
 
   bool _containsAny(String s, List<String> charsToSearchFor) {

--- a/test/list_to_csv_test.dart
+++ b/test/list_to_csv_test.dart
@@ -193,9 +193,20 @@ main() {
     expect(csv, equals(testCsvIssue5));
   });
 
-  test('Issue 7.  Test delimitAllFields', () {
+  test('Issue 7. Test delimitAllFields', () {
     var csv =
         const ListToCsvConverter().convert([singleRow], delimitAllFields: true);
     expect(csv, equals(csvSingleRowCommaDelimitAll));
+  });
+
+  test('Issue 34. Performance', () {
+    const converter = const ListToCsvConverter();
+    final stopwatch = Stopwatch()..start();
+    final sb = StringBuffer();
+    for (var i = 0; i < 10000; i++) {
+      converter.convertSingleRow(sb, singleRow, returnString: false);
+    }
+    stopwatch.stop();
+    expect(stopwatch.elapsedMilliseconds, lessThan(1000));
   });
 }


### PR DESCRIPTION
It turns out indeed that there was a performance issue. Namely, for each call to `convertSingleRow`, `sb.toString()` is called, which builds up a `String` of the entire CSV-output so far. The size of the output increases with each row, and therefor makes the conversion slower and slower. The return value was actually not used by `convert`.

To keep backwards compatibility with users that rely on the returned strings, I've added an option `returnString` which is `true` by default. The `convert` method sets it to `false`, so that it is optimized.

Users running into performance problems should pass `returnString: false` when calling `convertSingleRow` manually, and only use the `StringBuffer sb`.