### PR TITLE
Migration to Null-Safety

### DIFF
--- a/lib/csv.dart
+++ b/lib/csv.dart
@@ -30,7 +30,7 @@ class CsvCodec {
   CsvCodec(
       {String fieldDelimiter = defaultFieldDelimiter,
       String textDelimiter = defaultTextDelimiter,
-      String textEndDelimiter,
+      String? textEndDelimiter,
       String eol = defaultEol,
       bool shouldParseNumbers = true,
       bool allowInvalid = true,

--- a/lib/csv_settings_autodetection.dart
+++ b/lib/csv_settings_autodetection.dart
@@ -6,23 +6,23 @@ class CsvSettings {
   /// All fields which haven't been detected are null.
   /// Note however, that a null field could also mean, that the Detected
   /// doesn't care about this field.
-  final bool needMoreData;
+  final bool? needMoreData;
 
   /// If this value is null it wasn't detected (only possible if [needMoreDate]
   /// is true or the detector doesn't care about this field.
-  final String fieldDelimiter;
+  final String? fieldDelimiter;
 
   /// If this value is null it wasn't detected (only possible if [needMoreDate]
   /// is true or the detector doesn't care about this field.
-  final String textDelimiter;
+  final String? textDelimiter;
 
   /// If this value is null it wasn't detected (only possible if [needMoreDate]
   /// is true or the detector doesn't care about this field.
-  final String textEndDelimiter;
+  final String? textEndDelimiter;
 
   /// If this value is null it wasn't detected (only possible if [needMoreDate]
   /// is true or the detector doesn't care about this field.
-  final String eol;
+  final String? eol;
 
   const CsvSettings(this.fieldDelimiter, this.textDelimiter,
       this.textEndDelimiter, this.eol, this.needMoreData);
@@ -32,8 +32,8 @@ class CsvSettings {
 abstract class CsvSettingsDetector {
   CsvSettings detectFromString(String csv);
 
-  CsvSettings detectFromCsvChunks(List<String> csvChunks, bool noMoreChunks) {
-    var nullToEmpty = (String chunk) => chunk ?? '';
+  CsvSettings detectFromCsvChunks(List<String?> csvChunks, bool? noMoreChunks) {
+    var nullToEmpty = (String? chunk) => chunk ?? '';
     return detectFromString(csvChunks.map(nullToEmpty).join());
   }
 
@@ -47,7 +47,7 @@ abstract class CsvSettingsDetector {
 /// If there is only one possible value it returns this value immediately.
 ///
 /// If [csv] is null it becomes ''.
-String _findFirst(String csv, List<String> possibleValues) {
+String? _findFirst(String? csv, List<String> possibleValues) {
   csv ??= '';
 
   if (possibleValues.length == 1) {
@@ -55,12 +55,12 @@ String _findFirst(String csv, List<String> possibleValues) {
   }
 
   var bestMatchIndex = csv.length;
-  String bestMatch;
+  String? bestMatch;
 
   possibleValues.forEach((val) {
     if (val == null) return;
 
-    final currentIndex = csv.indexOf(val);
+    final currentIndex = csv!.indexOf(val);
 
     if (currentIndex != -1 && currentIndex < bestMatchIndex) {
       bestMatchIndex = currentIndex;
@@ -74,10 +74,10 @@ String _findFirst(String csv, List<String> possibleValues) {
 /// This is a very simple detector, which simple returns the value which has
 /// the lowest start position inside the csv.
 class FirstOccurrenceSettingsDetector extends CsvSettingsDetector {
-  final List<String> fieldDelimiters;
-  final List<String> textDelimiters;
-  final List<String> textEndDelimiters;
-  final List<String> eols;
+  final List<String>? fieldDelimiters;
+  final List<String>? textDelimiters;
+  final List<String>? textEndDelimiters;
+  final List<String>? eols;
 
   const FirstOccurrenceSettingsDetector(
       {this.fieldDelimiters,
@@ -89,8 +89,8 @@ class FirstOccurrenceSettingsDetector extends CsvSettingsDetector {
   CsvSettings detectFromString(String csv) {
     var needMoreData = false;
 
-    var tryValues = (List<String> values) {
-      String value;
+    var tryValues = (List<String>? values) {
+      String? value;
       if (values != null && values.isNotEmpty) {
         value = _findFirst(csv, values);
         if (value == null) needMoreData = true;
@@ -98,10 +98,10 @@ class FirstOccurrenceSettingsDetector extends CsvSettingsDetector {
       return value;
     };
 
-    String fieldDelimiter = tryValues(fieldDelimiters);
-    String textDelimiter = tryValues(textDelimiters);
-    String textEndDelimiter = tryValues(textEndDelimiters);
-    String eol = tryValues(eols);
+    String? fieldDelimiter = tryValues(fieldDelimiters);
+    String? textDelimiter = tryValues(textDelimiters);
+    String? textEndDelimiter = tryValues(textEndDelimiters);
+    String? eol = tryValues(eols);
 
     return new CsvSettings(
         fieldDelimiter, textDelimiter, textEndDelimiter, eol, needMoreData);

--- a/lib/csv_to_list_converter.dart
+++ b/lib/csv_to_list_converter.dart
@@ -8,19 +8,19 @@ part of csv;
 class CsvToListConverter extends StreamTransformerBase<String, List>
     implements ComplexChunkedConverter<String, List<List>> {
   /// The separator between fields.
-  final String fieldDelimiter;
+  final String? fieldDelimiter;
 
   /// The delimiter which (optionally) surrounds text / fields.
-  final String textDelimiter;
+  final String? textDelimiter;
 
   /// The end delimiter for text.  This allows text to be quoted with different
   /// start / end delimiters: Example:  «abc».
-  final String textEndDelimiter;
+  final String? textEndDelimiter;
 
   /// The end of line character which is expected after "row".
   ///
   /// The eol is optional for the last row.
-  final String eol;
+  final String? eol;
 
   /// Should we try to parse unquoted text to numbers (int and doubles)
   final bool shouldParseNumbers;
@@ -29,7 +29,7 @@ class CsvToListConverter extends StreamTransformerBase<String, List>
   final bool allowInvalid;
 
   /// An optional csvSettingsDetector.  See [CsvSettingsDetector].
-  final CsvSettingsDetector csvSettingsDetector;
+  final CsvSettingsDetector? csvSettingsDetector;
 
   /// The default values for the optional arguments are consistent with
   /// [rfc4180](http://tools.ietf.org/html/rfc4180).
@@ -38,12 +38,12 @@ class CsvToListConverter extends StreamTransformerBase<String, List>
   /// thrown.
   const CsvToListConverter(
       {this.fieldDelimiter = defaultFieldDelimiter,
-      String textDelimiter = defaultTextDelimiter,
-      String textEndDelimiter,
+      String? textDelimiter = defaultTextDelimiter,
+      String? textEndDelimiter,
       this.eol = defaultEol,
       this.csvSettingsDetector,
-      bool shouldParseNumbers,
-      bool allowInvalid})
+      bool? shouldParseNumbers,
+      bool? allowInvalid})
       : this.textDelimiter = textDelimiter,
         this.textEndDelimiter =
             textEndDelimiter != null ? textEndDelimiter : textDelimiter,
@@ -61,7 +61,7 @@ class CsvToListConverter extends StreamTransformerBase<String, List>
   ///
   /// Returns either an empty list, if there are not errors, or a list of
   /// errors.  If [throwError] throws an error if a setting is invalid.
-  List<ArgumentError> verifyCurrentSettings({bool throwError}) {
+  List<ArgumentError> verifyCurrentSettings({bool? throwError}) {
     return verifySettings(fieldDelimiter, textDelimiter, textEndDelimiter, eol,
         throwError: throwError);
   }
@@ -76,9 +76,9 @@ class CsvToListConverter extends StreamTransformerBase<String, List>
   ///
   /// Returns either an empty list, if there are not errors, or a list of
   /// errors.  If [throwError] throws an error if a setting is invalid.
-  static List<ArgumentError> verifySettings(String fieldDelimiter,
-      String textDelimiter, String textEndDelimiter, String eol,
-      {bool throwError}) {
+  static List<ArgumentError> verifySettings(String? fieldDelimiter,
+      String? textDelimiter, String? textEndDelimiter, String? eol,
+      {bool? throwError}) {
     return CsvParser.verifySettings(
         fieldDelimiter, textDelimiter, textEndDelimiter, eol);
   }
@@ -100,14 +100,14 @@ class CsvToListConverter extends StreamTransformerBase<String, List>
   }
 
   /// Parses the [csv] and returns a List (rows) of Lists (columns).
-  List<List> convert(String csv,
-      {String fieldDelimiter,
-      String textDelimiter,
-      String textEndDelimiter,
-      String eol,
-      CsvSettingsDetector csvSettingsDetector,
-      bool shouldParseNumbers,
-      bool allowInvalid}) {
+  List<List> convert(String? csv,
+      {String? fieldDelimiter,
+      String? textDelimiter,
+      String? textEndDelimiter,
+      String? eol,
+      CsvSettingsDetector? csvSettingsDetector,
+      bool? shouldParseNumbers,
+      bool? allowInvalid}) {
     fieldDelimiter ??= this.fieldDelimiter;
     textDelimiter ??= this.textDelimiter;
     textEndDelimiter ??= this.textEndDelimiter;
@@ -125,7 +125,7 @@ class CsvToListConverter extends StreamTransformerBase<String, List>
         textEndDelimiter,
         eol,
         shouldParseNumbers,
-        allowInvalid);
+        allowInvalid)!;
 
     return parser.convert(csv);
   }
@@ -136,21 +136,21 @@ class CsvToListConverter extends StreamTransformerBase<String, List>
   }
 }
 
-CsvParser _buildNewParserWithSettings(
-    List<String> unparsedCsvChunks,
-    bool noMoreChunks,
-    CsvSettingsDetector csvSettingsDetector,
-    String fieldDelimiter,
-    String textDelimiter,
-    String textEndDelimiter,
-    String eol,
+CsvParser? _buildNewParserWithSettings(
+    List<String?> unparsedCsvChunks,
+    bool? noMoreChunks,
+    CsvSettingsDetector? csvSettingsDetector,
+    String? fieldDelimiter,
+    String? textDelimiter,
+    String? textEndDelimiter,
+    String? eol,
     bool shouldParseNumbers,
     bool allowInvalid) {
   if (csvSettingsDetector != null) {
     var settings = csvSettingsDetector.detectFromCsvChunks(
         unparsedCsvChunks, noMoreChunks);
 
-    if (settings.needMoreData && !noMoreChunks) return null;
+    if (settings.needMoreData! && !noMoreChunks!) return null;
 
     fieldDelimiter = settings.fieldDelimiter ?? fieldDelimiter;
     textDelimiter = settings.textDelimiter ?? textDelimiter;
@@ -174,17 +174,17 @@ class CsvToListSink extends ChunkedConversionSink<String> {
 
   /// The csv parser which has the configurations (delimiter, eol,...) already
   /// set.
-  CsvParser _parser;
+  CsvParser? _parser;
 
-  List<String> _unparsedCsvChunks;
+  List<String?> _unparsedCsvChunks;
 
   List _currentRow;
 
-  final String _fieldDelimiter;
-  final String _textDelimiter;
-  final String _textEndDelimiter;
-  final String _eol;
-  final CsvSettingsDetector _csvSettingsDetector;
+  final String? _fieldDelimiter;
+  final String? _textDelimiter;
+  final String? _textEndDelimiter;
+  final String? _eol;
+  final CsvSettingsDetector? _csvSettingsDetector;
   bool _shouldParseNumbers;
   bool _allowInvalid;
 
@@ -200,7 +200,7 @@ class CsvToListSink extends ChunkedConversionSink<String> {
       : _currentRow = [],
         _unparsedCsvChunks = [];
 
-  _add(String newCsvChunk, {bool fieldCompleteWhenEndOfString}) {
+  _add(String? newCsvChunk, {bool? fieldCompleteWhenEndOfString}) {
     newCsvChunk ??= '';
     _unparsedCsvChunks.add(newCsvChunk);
 
@@ -218,12 +218,12 @@ class CsvToListSink extends ChunkedConversionSink<String> {
           _eol,
           _shouldParseNumbers,
           _allowInvalid);
-      assert(_parser != null || !fieldCompleteWhenEndOfString);
+      assert(_parser != null || !fieldCompleteWhenEndOfString!);
       if (_parser == null) return; // and wait for another chunk
     }
 
     for (int i = 0; i < _unparsedCsvChunks.length; ++i) {
-      String csvChunk = _unparsedCsvChunks[i];
+      String? csvChunk = _unparsedCsvChunks[i];
 
       final isLastCsvChunk = (i + 1) == _unparsedCsvChunks.length;
 
@@ -231,8 +231,8 @@ class CsvToListSink extends ChunkedConversionSink<String> {
 
       // Parse rows until EndOfString.
       for (;;) {
-        final end = isLastCsvChunk && fieldCompleteWhenEndOfString;
-        final result = _parser.convertRow(csvChunk, _currentRow,
+        final end = isLastCsvChunk && fieldCompleteWhenEndOfString!;
+        final result = _parser!.convertRow(csvChunk, _currentRow,
             continueCsv: continueCsv, fieldCompleteWhenEndOfString: end);
 
         continueCsv = true;

--- a/lib/list_to_csv_converter.dart
+++ b/lib/list_to_csv_converter.dart
@@ -104,7 +104,7 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
   const ListToCsvConverter(
       {this.fieldDelimiter = defaultFieldDelimiter,
       String textDelimiter = defaultTextDelimiter,
-      String textEndDelimiter,
+      String? textEndDelimiter,
       this.eol = defaultEol,
       this.delimitAllFields = defaultDelimitAllFields})
       : this.textDelimiter = textDelimiter,
@@ -123,18 +123,18 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
   /// All other rfc rules are followed.
   ///
   /// If [rows] is null an empty String is returned.
-  String convert(List<List> rows,
-      {String fieldDelimiter,
-      String textDelimiter,
-      String textEndDelimiter,
-      String eol,
-      bool delimitAllFields}) {
+  String convert(List<List?>? rows,
+      {String? fieldDelimiter,
+      String? textDelimiter,
+      String? textEndDelimiter,
+      String? eol,
+      bool? delimitAllFields}) {
     if (rows == null) return '';
 
     eol ??= this.eol;
 
     var sb = new StringBuffer();
-    var sep = '';
+    String? sep = '';
     rows.forEach((r) {
       sb.write(sep);
       sep = eol;
@@ -189,12 +189,12 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
   /// If [returnString] is true (default), returns the converted String.
   /// Otherwise output is only written to provided StringBuffer [sb].  Set to
   /// false to improve performance.
-  String convertSingleRow(StringBuffer sb, List rowValues,
-      {String fieldDelimiter,
-      String textDelimiter,
-      String textEndDelimiter,
-      String eol,
-      bool delimitAllFields,
+  String? convertSingleRow(StringBuffer sb, List? rowValues,
+      {String? fieldDelimiter,
+      String? textDelimiter,
+      String? textEndDelimiter,
+      String? eol,
+      bool? delimitAllFields,
       bool returnString = true}) {
     if (rowValues == null || rowValues.isEmpty) return '';
 
@@ -217,7 +217,7 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
           'Field Delimiter ($fieldDelimiter) and Text Delimiter ($textDelimiter) must not be equal.');
     }
 
-    var fieldDel = '';
+    String? fieldDel = '';
 
     // Comments assume field and text delimiter are default.
     // [val] _in the comments changes_ depending on the operation after the comment.
@@ -227,13 +227,13 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
 
       // 5,3 should become "5,3"
 
-      if (delimitAllFields ||
+      if (delimitAllFields! ||
           _containsAny(valString,
               [fieldDelimiter, textDelimiter, textEndDelimiter, eol])) {
         // ab"cd => ab""cd
         if (_containsAny(valString, [textEndDelimiter])) {
           var newEndDelimiter = "$textEndDelimiter$textEndDelimiter";
-          valString = valString.replaceAll(textEndDelimiter, newEndDelimiter);
+          valString = valString.replaceAll(textEndDelimiter!, newEndDelimiter);
         }
 
         sb
@@ -251,9 +251,9 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
     return returnString ? sb.toString() : null;
   }
 
-  bool _containsAny(String s, List<String> charsToSearchFor) {
+  bool _containsAny(String s, List<String?> charsToSearchFor) {
     var chars = new Set<int>();
-    charsToSearchFor.forEach((word) => chars.addAll(word.codeUnits));
+    charsToSearchFor.forEach((word) => chars.addAll(word!.codeUnits));
     var it = s.codeUnits.iterator;
     while (it.moveNext()) {
       if (chars.contains(it.current)) return true;

--- a/lib/list_to_csv_converter.dart
+++ b/lib/list_to_csv_converter.dart
@@ -133,10 +133,6 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
 
     eol ??= this.eol;
 
-    if (eol == null) {
-      throw new ArgumentError('Eol string must not be null');
-    }
-
     var sb = new StringBuffer();
     var sep = '';
     rows.forEach((r) {

--- a/lib/src/complex_converter.dart
+++ b/lib/src/complex_converter.dart
@@ -25,7 +25,7 @@ class ComplexConverterStreamEventSink<S, T> implements EventSink<S> {
     _chunkedSink.add(o);
   }
 
-  void addError(Object error, [StackTrace stackTrace]) {
+  void addError(Object error, [StackTrace? stackTrace]) {
     _eventSink.addError(error, stackTrace);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,5 +12,5 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 
 dev_dependencies:
-  test: ^1.0.0
-  pedantic: '1.4.0'
+  test: ^1.16.0-nullsafety.16
+  pedantic: ^1.10.0-nullsafety.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csv
-version: 4.1.0
+version: 5.0.0-nullsafety.0
 author: Christian Loitsch <christian@loitsch.com>
 description: |-
   A codec to transform between a string and a list of values.
@@ -9,7 +9,7 @@ homepage: https://github.com/close2/csv
 documentation: https://github.com/close2/csv
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.12.0-133.7.beta <3.0.0'
 
 dev_dependencies:
   test: ^1.16.0-nullsafety.16

--- a/test/csv_to_list_test.dart
+++ b/test/csv_to_list_test.dart
@@ -382,14 +382,14 @@ main_converter() {
       () => expect(commaDoubleQuotCsvToListConverter.convert(''), equals([])));
 
   test('Parses a multiline csv string correctly (different eols)', () {
-    var eol = commaDoubleQuotCsvToListConverterParseNumbers.eol;
+    var eol = commaDoubleQuotCsvToListConverterParseNumbers.eol!;
     expect(eol, equals('\r\n'));
     var csv =
         csvSingleRowComma + eol + csvSingleRowComma + eol + csvSingleRowComma;
     expect(commaDoubleQuotCsvToListConverterParseNumbers.convert(csv),
         equals(multipleRows));
 
-    eol = dotSingleQuotCsvToListConverterUnixEol.eol;
+    eol = dotSingleQuotCsvToListConverterUnixEol.eol!;
     expect(eol, equals('\n'));
     csv = csvSingleRowDotSingleQuot +
         eol +

--- a/test/list_to_csv_test.dart
+++ b/test/list_to_csv_test.dart
@@ -97,22 +97,18 @@ main() {
   });
 
   test(
-      'Throw an exception if field Delimiter and text Delimiter are equal or '
-      'either is null', () {
+      'Throw an exception if field Delimiter and text Delimiter are equal', () {
     sb.clear();
     expect(() {
       var converter =
           const ListToCsvConverter(fieldDelimiter: 'a', textDelimiter: 'a');
       converter.convertSingleRow(sb, singleRow);
     }, throwsArgumentError);
+
     expect(() {
       var converter = commaDoubleQuotListToCsvConverter;
       converter.convertSingleRow(sb, singleRow,
           fieldDelimiter: 'a', textDelimiter: 'a');
-    }, throwsArgumentError);
-    expect(() {
-      new ListToCsvConverter(fieldDelimiter: null, textDelimiter: null)
-          .convertSingleRow(sb, singleRow);
     }, throwsArgumentError);
   });
 
@@ -166,11 +162,6 @@ main() {
   test('Returns an empty string when rows is null or empty', () {
     expect(commaDoubleQuotListToCsvConverter.convert(null), equals(''));
     expect(commaDoubleQuotListToCsvConverter.convert([]), equals(''));
-  });
-
-  test('Throw an exception if eol is null', () {
-    expect(() => new ListToCsvConverter(eol: null).convert([singleRow]),
-        throwsArgumentError);
   });
 
   var multipleRowsStream = new Stream.fromIterable(multipleRows);


### PR DESCRIPTION
Followed official migration guide here: https://dart.dev/null-safety/migration-guide

- [x] Update dependencies
- [x] Run migration tool
- [x] Run analyzer
- [x] Run Tests
- [x] Set sdk constraints
- [x] Bump package version

Was looking to upgrade my own project and this was the only package dependency that didn't have null safety yet. I did my best to not change the API, wherever it was ambiguous I left it nullable, therefore as it was. There's one or 2 behaviours under test affected, fairly edge case ones that are just as well off IMO. See the diff on the tests.

Thanks for the great lib!