### PR TITLE
release to nullsafety 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # 5.0.0-nullsafety.0
 nullsafety
+updating dependencies to released nullsafety version
+Removing unnecessary const and new keywords
+
+Thanks to: https://github.com/arnaudelub
+
+# 5.0.0-nullsafety.0
+nullsafety
 Thanks to: https://github.com/darwingr
 
 # 4.1.0
-Add `returnString` option to work around a major performance bug.  
+Add `returnString` option to work around a major performance bug.
 Thanks: @boukeversteegh
 
 # 4.0.3
@@ -14,4 +21,3 @@ Fix analysis errors.  No new functionality.  No bug fix.
 
 # 4.0.1
 update dependencies for dart sdk 2.1
-

--- a/lib/csv.dart
+++ b/lib/csv.dart
@@ -35,14 +35,14 @@ class CsvCodec {
       bool shouldParseNumbers = true,
       bool allowInvalid = true,
       bool delimitAllFields = defaultDelimitAllFields})
-      : decoder = new CsvToListConverter(
+      : decoder = CsvToListConverter(
             fieldDelimiter: fieldDelimiter,
             textDelimiter: textDelimiter,
             textEndDelimiter: textEndDelimiter,
             eol: eol,
             shouldParseNumbers: shouldParseNumbers,
             allowInvalid: allowInvalid),
-        encoder = new ListToCsvConverter(
+        encoder = ListToCsvConverter(
             fieldDelimiter: fieldDelimiter,
             textDelimiter: textDelimiter,
             textEndDelimiter: textEndDelimiter,

--- a/lib/csv_settings_autodetection.dart
+++ b/lib/csv_settings_autodetection.dart
@@ -103,7 +103,7 @@ class FirstOccurrenceSettingsDetector extends CsvSettingsDetector {
     String? textEndDelimiter = tryValues(textEndDelimiters);
     String? eol = tryValues(eols);
 
-    return new CsvSettings(
+    return CsvSettings(
         fieldDelimiter, textDelimiter, textEndDelimiter, eol, needMoreData);
   }
 }

--- a/lib/csv_to_list_converter.dart
+++ b/lib/csv_to_list_converter.dart
@@ -88,7 +88,7 @@ class CsvToListConverter extends StreamTransformerBase<String, List>
   /// specifying the type here.)
   @override
   CsvToListSink startChunkedConversion(Sink outputSink) {
-    return new CsvToListSink(
+    return CsvToListSink(
         outputSink as Sink<List>,
         fieldDelimiter,
         textDelimiter,
@@ -131,8 +131,8 @@ class CsvToListConverter extends StreamTransformerBase<String, List>
   }
 
   Stream<List> bind(Stream<String> stream) {
-    return new Stream<List>.eventTransformed(stream,
-        (EventSink sink) => new ComplexConverterStreamEventSink(this, sink));
+    return Stream<List>.eventTransformed(stream,
+        (EventSink sink) => ComplexConverterStreamEventSink(this, sink));
   }
 }
 
@@ -158,7 +158,7 @@ CsvParser? _buildNewParserWithSettings(
     eol = settings.eol ?? eol;
   }
 
-  return new CsvParser(
+  return CsvParser(
       fieldDelimiter: fieldDelimiter,
       textDelimiter: textDelimiter,
       textEndDelimiter: textEndDelimiter,

--- a/lib/list_to_csv_converter.dart
+++ b/lib/list_to_csv_converter.dart
@@ -133,7 +133,7 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
 
     eol ??= this.eol;
 
-    var sb = new StringBuffer();
+    var sb = StringBuffer();
     String? sep = '';
     rows.forEach((r) {
       sb.write(sep);
@@ -167,7 +167,7 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
   /// specifying the type here.)
   @override
   List2CsvSink startChunkedConversion(Sink<String> outputSink) {
-    return new List2CsvSink(this, outputSink);
+    return List2CsvSink(this, outputSink);
   }
 
   /// Converts a list of values representing a row into a value separated
@@ -208,12 +208,12 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
     delimitAllFields ??= this.delimitAllFields;
 
     if (fieldDelimiter == null || textDelimiter == null) {
-      throw new ArgumentError(
+      throw ArgumentError(
           'Field Delimiter ($fieldDelimiter) and Text Delimiter ($textDelimiter) must not be null.');
     }
 
     if (fieldDelimiter == textDelimiter) {
-      throw new ArgumentError(
+      throw ArgumentError(
           'Field Delimiter ($fieldDelimiter) and Text Delimiter ($textDelimiter) must not be equal.');
     }
 
@@ -252,7 +252,7 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
   }
 
   bool _containsAny(String s, List<String?> charsToSearchFor) {
-    var chars = new Set<int>();
+    var chars = Set<int>();
     charsToSearchFor.forEach((word) => chars.addAll(word!.codeUnits));
     var it = s.codeUnits.iterator;
     while (it.moveNext()) {
@@ -262,8 +262,8 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
   }
 
   Stream<String> bind(Stream<List> stream) {
-    return new Stream<String>.eventTransformed(stream,
-        (EventSink sink) => new ComplexConverterStreamEventSink(this, sink));
+    return Stream<String>.eventTransformed(stream,
+        (EventSink sink) => ComplexConverterStreamEventSink(this, sink));
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csv
-version: 5.0.0-nullsafety.0
+version: 5.0.0
 description: |-
   A codec to transform between a string and a list of values.
 
@@ -11,5 +11,5 @@ environment:
   sdk: '>=2.12.0-133.7.beta <3.0.0'
 
 dev_dependencies:
-  test: ^1.16.0-nullsafety.16
-  pedantic: ^1.10.0-nullsafety.3
+  test: ^1.16.8
+  pedantic: ^1.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ homepage: https://github.com/close2/csv
 documentation: https://github.com/close2/csv
 
 environment:
-  sdk: '>=2.12.0-133.7.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
   test: ^1.16.8

--- a/test/csv_to_list_test.dart
+++ b/test/csv_to_list_test.dart
@@ -2,7 +2,7 @@ library csv_to_list_test;
 
 import 'dart:async';
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 import 'package:csv/csv.dart';
 import 'package:csv/src/csv_parser.dart';
 import 'package:csv/csv_settings_autodetection.dart';
@@ -10,48 +10,48 @@ import 'package:csv/csv_settings_autodetection.dart';
 import 'test_data.dart';
 
 final commaDoubleQuotCsvToListConverter =
-    new CsvToListConverter(shouldParseNumbers: false);
-final commaDoubleQuotCsvToListConverterParseNumbers = new CsvToListConverter();
+    CsvToListConverter(shouldParseNumbers: false);
+final commaDoubleQuotCsvToListConverterParseNumbers = CsvToListConverter();
 final semicolonDoubleQuotCsvToListConverter =
-    new CsvToListConverter(fieldDelimiter: ';', shouldParseNumbers: false);
+    CsvToListConverter(fieldDelimiter: ';', shouldParseNumbers: false);
 final dotDoubleQuotCsvToListConverter =
-    new CsvToListConverter(fieldDelimiter: '.', shouldParseNumbers: false);
-final dotSingleQuotCsvToListConverterUnixEol = new CsvToListConverter(
+    CsvToListConverter(fieldDelimiter: '.', shouldParseNumbers: false);
+final dotSingleQuotCsvToListConverterUnixEol = CsvToListConverter(
     fieldDelimiter: '.',
     textDelimiter: "'",
     eol: '\n',
     shouldParseNumbers: false);
-final dotSingleQuotCsvToListConverterUnixEol_double = new CsvToListConverter(
+final dotSingleQuotCsvToListConverterUnixEol_double = CsvToListConverter(
     fieldDelimiter: '.',
     textDelimiter: "'",
     textEndDelimiter: '"',
     eol: '\n',
     shouldParseNumbers: false);
-final aaBbCsvToListConverter = new CsvToListConverter(
+final aaBbCsvToListConverter = CsvToListConverter(
     fieldDelimiter: 'aa', textDelimiter: 'bb', shouldParseNumbers: false);
-final complexConverter = new CsvToListConverter(
+final complexConverter = CsvToListConverter(
     fieldDelimiter: '...*',
     textDelimiter: '...#',
     eol: '....',
     shouldParseNumbers: true);
-final complex2Converter = new CsvToListConverter(
+final complex2Converter = CsvToListConverter(
     fieldDelimiter: '...*',
     textDelimiter: '...#',
     eol: '.*.*',
     shouldParseNumbers: true);
-final complex3Converter = new CsvToListConverter(
+final complex3Converter = CsvToListConverter(
     fieldDelimiter: ',',
     textDelimiter: '.,a,b,__',
     eol: '_xyz',
     shouldParseNumbers: true);
 
-main() {
+void main() {
   main_converter();
 
   main_transformer();
 
   test('Argument verification works', () {
-    final parser = new CsvParser();
+    final parser = CsvParser();
     expect(parser.verifyCurrentSettings(), equals([]));
 
     var errors =
@@ -74,15 +74,15 @@ main() {
   });
 }
 
-main_transformer() {
+void main_transformer() {
   test('Works as transformer (simple test)', () {
-    var stream = new Stream.fromIterable([csvSimpleStringsSingleRowComma]);
+    var stream = Stream.fromIterable([csvSimpleStringsSingleRowComma]);
     var f_rows = stream.transform(commaDoubleQuotCsvToListConverter).toList();
     expect(f_rows, completion([simpleStringsSingleRow]));
   });
 
   test('Works as transformer (complex multicharacter delimiters)', () {
-    var csvStream = new Stream.fromIterable(csvComplex_parts);
+    var csvStream = Stream.fromIterable(csvComplex_parts);
     var f_rows = csvStream.transform(complexConverter).toList();
     expect(f_rows, completion(complexRows));
   });
@@ -90,11 +90,11 @@ main_transformer() {
   test(
       'Works as transformer '
       '(complex multicharacter delimiters, difficult line endings)', () {
-    var csvStream = new Stream.fromIterable(csvComplex_parts_ending1);
+    var csvStream = Stream.fromIterable(csvComplex_parts_ending1);
     var f_rows = csvStream.transform(complexConverter).toList();
     expect(f_rows, completion(complexRows_ending1));
 
-    var csvStream2 = new Stream.fromIterable(csvComplex_parts_ending2);
+    var csvStream2 = Stream.fromIterable(csvComplex_parts_ending2);
     var f_rows2 = csvStream2.transform(complexConverter).toList();
     expect(f_rows2, completion(complexRows_ending2));
   });
@@ -102,7 +102,7 @@ main_transformer() {
   test(
       'Works as transformer '
       '(complex multicharacter delimiters, repeating patterns)', () {
-    var csvStream = new Stream.fromIterable(csvComplex2_parts);
+    var csvStream = Stream.fromIterable(csvComplex2_parts);
     var f_rows = csvStream.transform(complex2Converter).toList();
     expect(f_rows, completion(complexRows2));
   });
@@ -110,7 +110,7 @@ main_transformer() {
   test(
       'Works as transformer '
       '(complex multicharacter delimiters, "embedded" patterns)', () {
-    var csvStream = new Stream.fromIterable(csvComplex3_parts);
+    var csvStream = Stream.fromIterable(csvComplex3_parts);
     var f_rows = csvStream.transform(complex3Converter).toList();
     expect(f_rows, completion(complexRows3));
   });
@@ -118,9 +118,9 @@ main_transformer() {
   test(
       'Transformer throws an exception if not allowInvalid and csv ends '
       'without text end delimiter', () {
-    const List<String> csv = const ['abc,"d', 'ef,xyz'];
-    final csvStream = new Stream.fromIterable(csv);
-    final converter = new CsvToListConverter(allowInvalid: false);
+    const csv = ['abc,"d', 'ef,xyz'];
+    final csvStream = Stream.fromIterable(csv);
+    final converter = CsvToListConverter(allowInvalid: false);
 
     var fun = () => csvStream.transform(converter).toList();
 
@@ -129,68 +129,68 @@ main_transformer() {
 
   test('Transformer throws an exception if not allowInvalid and eol is null',
       () {
-    var csvStream = new Stream.fromIterable(csvComplex3_parts);
-    final converter = new CsvToListConverter(eol: null, allowInvalid: false);
+    var csvStream = Stream.fromIterable(csvComplex3_parts);
+    final converter = CsvToListConverter(eol: null, allowInvalid: false);
 
     var fun = () => csvStream.transform(converter).toList();
     expect(fun(), throwsArgumentError);
   });
 
   test('Autodetecting settings works in transformer mode', () {
-    var det = new FirstOccurrenceSettingsDetector(
+    var det = FirstOccurrenceSettingsDetector(
         fieldDelimiters: [',', ';'],
         textDelimiters: ['"', "'"],
         textEndDelimiters: ['"', "'"],
         eols: ['\r\n', '\n']);
-    var converter = new CsvToListConverter(
-        csvSettingsDetector: det, shouldParseNumbers: true);
-    var stream = new Stream.fromIterable([csvSimpleStringsSingleRowComma]);
+    var converter =
+        CsvToListConverter(csvSettingsDetector: det, shouldParseNumbers: true);
+    var stream = Stream.fromIterable([csvSimpleStringsSingleRowComma]);
     var f_rows = stream.transform(converter).toList();
     expect(f_rows, completion([simpleStringsSingleRow]));
 
-    det = new FirstOccurrenceSettingsDetector(
+    det = FirstOccurrenceSettingsDetector(
         fieldDelimiters: [',', 'b'],
         textDelimiters: ["'", '"'],
         textEndDelimiters: ['.', '"'],
         eols: ['\n']);
-    converter = new CsvToListConverter(
-        csvSettingsDetector: det, shouldParseNumbers: false);
-    stream = new Stream.fromIterable([csvSingleRowComma]);
+    converter =
+        CsvToListConverter(csvSettingsDetector: det, shouldParseNumbers: false);
+    stream = Stream.fromIterable([csvSingleRowComma]);
     f_rows = stream.transform(converter).toList();
     expect(f_rows, completion([singleRowAllText]));
 
-    det = new FirstOccurrenceSettingsDetector(
+    det = FirstOccurrenceSettingsDetector(
         fieldDelimiters: ['aa', '2'],
         textDelimiters: ['bb', '"'],
         textEndDelimiters: ['"', 'bb']);
-    converter = new CsvToListConverter(
-        csvSettingsDetector: det, shouldParseNumbers: true);
-    stream = new Stream.fromIterable([csvSingleRowAaBb]);
+    converter =
+        CsvToListConverter(csvSettingsDetector: det, shouldParseNumbers: true);
+    stream = Stream.fromIterable([csvSingleRowAaBb]);
     f_rows = stream.transform(converter).toList();
     expect(f_rows, completion([singleRow]));
   });
 
   test('Transformer autodetects settings for a multiline csv correctly', () {
-    var det = new FirstOccurrenceSettingsDetector(eols: ['\r\n', '\n']);
-    var converter = new CsvToListConverter(csvSettingsDetector: det);
+    var det = FirstOccurrenceSettingsDetector(eols: ['\r\n', '\n']);
+    var converter = CsvToListConverter(csvSettingsDetector: det);
     var eol = '\n';
-    var csvStream = new Stream.fromIterable(
+    var csvStream = Stream.fromIterable(
         [csvSingleRowComma, eol, csvSingleRowComma, eol, csvSingleRowComma]);
     var f_rows = csvStream.transform(converter).toList();
     expect(f_rows, completion(multipleRows));
 
-    det = new FirstOccurrenceSettingsDetector(
+    det = FirstOccurrenceSettingsDetector(
         eols: ['\r\n', '\n'],
         textDelimiters: ['""', "'"],
         textEndDelimiters: ['««', '!']);
-    converter = new CsvToListConverter(csvSettingsDetector: det);
-    csvStream = new Stream.fromIterable(autodetectCsv_parts);
+    converter = CsvToListConverter(csvSettingsDetector: det);
+    csvStream = Stream.fromIterable(autodetectCsv_parts);
     f_rows = csvStream.transform(converter).toList();
     expect(f_rows, completion(autodetectRows));
   });
 }
 
-main_converter() {
+void main_converter() {
   test('Csv converter has sane default values and stores parameters', () {
     expect(commaDoubleQuotCsvToListConverter.fieldDelimiter, equals(','));
     expect(commaDoubleQuotCsvToListConverter.textDelimiter, equals('"'));
@@ -307,7 +307,7 @@ main_converter() {
   test('Can parse different formats when text end delimiter is different', () {
     expect(
         commaDoubleQuotCsvToListConverterParseNumbers
-            .convert(csvSingleRowComma_endQuotXY, textEndDelimiter: "XY"),
+            .convert(csvSingleRowComma_endQuotXY, textEndDelimiter: 'XY'),
         equals([singleRow]));
     expect(
         semicolonDoubleQuotCsvToListConverter.convert(
@@ -334,7 +334,7 @@ main_converter() {
         equals([singleRowNoDouble]));
     expect(
         aaBbCsvToListConverter.convert(csvSingleRowAaBbXy,
-            shouldParseNumbers: true, textEndDelimiter: "XY"),
+            shouldParseNumbers: true, textEndDelimiter: 'XY'),
         equals([singleRow]));
   });
 
@@ -342,7 +342,7 @@ main_converter() {
       'Throw an exception if allowInvalid is false and field Delimiter and '
       'text Delimiter are equal or either is null', () {
     expect(
-        () => new CsvToListConverter(
+        () => CsvToListConverter(
                 fieldDelimiter: 'a', textDelimiter: 'a', allowInvalid: false)
             .convert('a,b'),
         throwsArgumentError);
@@ -351,7 +351,7 @@ main_converter() {
             fieldDelimiter: 'a', textDelimiter: 'a', allowInvalid: false),
         throwsArgumentError);
     expect(
-        () => new CsvToListConverter(
+        () => CsvToListConverter(
                 fieldDelimiter: null, textDelimiter: null, allowInvalid: false)
             .convert('a,b'),
         throwsArgumentError);
@@ -361,7 +361,7 @@ main_converter() {
       'Doesn\'t throw an exception if allowInvalid and field Delimiter and '
       'text Delimiter are equal or either is null', () {
     expect(
-        new CsvToListConverter(fieldDelimiter: 'a', textDelimiter: 'a')
+        CsvToListConverter(fieldDelimiter: 'a', textDelimiter: 'a')
             .convert('a,b'),
         isNotNull);
     expect(
@@ -369,7 +369,7 @@ main_converter() {
             fieldDelimiter: 'a', textDelimiter: 'a'),
         isNotNull);
     expect(
-        () => new CsvToListConverter(fieldDelimiter: null, textDelimiter: null)
+        () => CsvToListConverter(fieldDelimiter: null, textDelimiter: null)
             .convert('a,b'),
         isNotNull);
   });
@@ -402,14 +402,13 @@ main_converter() {
 
   test('Throw an exception if allowInvalid is false and eol is null', () {
     expect(
-        () =>
-            new CsvToListConverter(eol: null, allowInvalid: false).convert('a'),
+        () => CsvToListConverter(eol: null, allowInvalid: false).convert('a'),
         throwsArgumentError);
   });
 
   test('Doesn\'t throw an exception if allowInvalid and eol is null', () {
     expect(
-        new CsvToListConverter(eol: null).convert('a'),
+        CsvToListConverter(eol: null).convert('a'),
         equals([
           ['a']
         ]));
@@ -437,13 +436,13 @@ main_converter() {
   test(
       'Throws an exception if not allowInvalid and csv ends without '
       'text end delimiter', () {
-    const String csv = 'abc,"def,xyz';
-    expect(() => new CsvToListConverter(allowInvalid: false).convert(csv),
+    const csv = 'abc,"def,xyz';
+    expect(() => CsvToListConverter(allowInvalid: false).convert(csv),
         throwsFormatException);
   });
 
   test('Autodetecting settings works in converter mode', () {
-    var det = new FirstOccurrenceSettingsDetector(
+    var det = FirstOccurrenceSettingsDetector(
         fieldDelimiters: [',', ';'],
         textDelimiters: ['"', "'"],
         textEndDelimiters: ['"', "'"],
@@ -453,7 +452,7 @@ main_converter() {
             csvSettingsDetector: det, shouldParseNumbers: true),
         equals([simpleStringsSingleRow]));
 
-    det = new FirstOccurrenceSettingsDetector(
+    det = FirstOccurrenceSettingsDetector(
         fieldDelimiters: [',', 'b'],
         textDelimiters: ["'", '"'],
         textEndDelimiters: ['.', '"'],
@@ -463,7 +462,7 @@ main_converter() {
             csvSettingsDetector: det, shouldParseNumbers: false),
         equals([singleRowAllText]));
 
-    det = new FirstOccurrenceSettingsDetector(
+    det = FirstOccurrenceSettingsDetector(
         fieldDelimiters: ['aa', '2'],
         textDelimiters: ['bb', '"'],
         textEndDelimiters: ['"', 'bb']);
@@ -474,20 +473,19 @@ main_converter() {
   });
 
   test('Autodetects settings for a multiline csv string correctly', () {
-    var det = new FirstOccurrenceSettingsDetector(eols: ['\r\n', '\n']);
-    var converter = new CsvToListConverter(csvSettingsDetector: det);
+    var det = FirstOccurrenceSettingsDetector(eols: ['\r\n', '\n']);
+    var converter = CsvToListConverter(csvSettingsDetector: det);
     var eol = '\n';
     var csv =
         csvSingleRowComma + eol + csvSingleRowComma + eol + csvSingleRowComma;
     expect(converter.convert(csv), equals(multipleRows));
 
-    det = new FirstOccurrenceSettingsDetector(
+    det = FirstOccurrenceSettingsDetector(
         eols: ['\r\n', '\n'],
         textDelimiters: ['""', "'"],
         textEndDelimiters: ['««', '!']);
     csv = autodetectCsv;
-    expect(new CsvToListConverter(csvSettingsDetector: det).convert(csv),
+    expect(CsvToListConverter(csvSettingsDetector: det).convert(csv),
         equals(autodetectRows));
   });
 }
-

--- a/test/list_to_csv_test.dart
+++ b/test/list_to_csv_test.dart
@@ -8,29 +8,28 @@ import 'package:csv/csv.dart';
 import 'test_data.dart';
 
 main() {
-  const commaDoubleQuotListToCsvConverter = const ListToCsvConverter();
+  const commaDoubleQuotListToCsvConverter = ListToCsvConverter();
   const semicolonDoubleQuotListToCsvConverter =
-      const ListToCsvConverter(fieldDelimiter: ';');
+      ListToCsvConverter(fieldDelimiter: ';');
   const dotDoubleQuotListToCsvConverter =
-      const ListToCsvConverter(fieldDelimiter: '.');
-  const dotSingleQuotListToCsvConverterUnixEol = const ListToCsvConverter(
-      fieldDelimiter: '.', textDelimiter: "'", eol: '\n');
+      ListToCsvConverter(fieldDelimiter: '.');
+  const dotSingleQuotListToCsvConverterUnixEol =
+      ListToCsvConverter(fieldDelimiter: '.', textDelimiter: "'", eol: '\n');
   const aaBbListToCsvConverter =
-      const ListToCsvConverter(fieldDelimiter: 'aa', textDelimiter: 'bb');
+      ListToCsvConverter(fieldDelimiter: 'aa', textDelimiter: 'bb');
 
   const commaDoubleQuotListToCsvConverter_xy =
-      const ListToCsvConverter(textEndDelimiter: 'XY');
+      ListToCsvConverter(textEndDelimiter: 'XY');
   const semicolonDoubleQuotListToCsvConverter_xy =
-      const ListToCsvConverter(fieldDelimiter: ';', textEndDelimiter: 'XY');
+      ListToCsvConverter(fieldDelimiter: ';', textEndDelimiter: 'XY');
   const dotDoubleQuotListToCsvConverter_xy =
-      const ListToCsvConverter(fieldDelimiter: '.', textEndDelimiter: 'XY');
-  const dotSingleQuotListToCsvConverterUnixEol_double =
-      const ListToCsvConverter(
-          fieldDelimiter: '.',
-          textDelimiter: "'",
-          textEndDelimiter: '"',
-          eol: '\n');
-  const aaBbListToCsvConverter_xy = const ListToCsvConverter(
+      ListToCsvConverter(fieldDelimiter: '.', textEndDelimiter: 'XY');
+  const dotSingleQuotListToCsvConverterUnixEol_double = ListToCsvConverter(
+      fieldDelimiter: '.',
+      textDelimiter: "'",
+      textEndDelimiter: '"',
+      eol: '\n');
+  const aaBbListToCsvConverter_xy = ListToCsvConverter(
       fieldDelimiter: 'aa', textDelimiter: 'bb', textEndDelimiter: 'XY');
 
   test('Csv converter has sane default values and stores parameters', () {
@@ -45,7 +44,7 @@ main() {
     expect(dotSingleQuotListToCsvConverterUnixEol.eol, equals('\n'));
   });
 
-  var sb = new StringBuffer();
+  var sb = StringBuffer();
 
   test(
       'A single simple row converts into a separated value string '
@@ -89,15 +88,15 @@ main() {
     expect(sb.toString(), equals(csvSingleRowAaBbXy));
   });
 
-  test("Can override field and text delimiter", () {
+  test('Can override field and text delimiter', () {
     dotSingleQuotListToCsvConverterUnixEol.convertSingleRow(
         sb..clear(), singleRow,
         fieldDelimiter: ',', textDelimiter: '"', textEndDelimiter: '"');
     expect(sb.toString(), equals(csvSingleRowComma));
   });
 
-  test(
-      'Throw an exception if field Delimiter and text Delimiter are equal', () {
+  test('Throw an exception if field Delimiter and text Delimiter are equal',
+      () {
     sb.clear();
     expect(() {
       var converter =
@@ -164,7 +163,7 @@ main() {
     expect(commaDoubleQuotListToCsvConverter.convert([]), equals(''));
   });
 
-  var multipleRowsStream = new Stream.fromIterable(multipleRows);
+  var multipleRowsStream = Stream.fromIterable(multipleRows);
   test('Works as transformer', () {
     var eol = commaDoubleQuotListToCsvConverter.eol;
     var result = csvSingleRowComma +
@@ -191,7 +190,7 @@ main() {
   });
 
   test('Issue 34. Performance', () {
-    const converter = const ListToCsvConverter();
+    const converter = ListToCsvConverter();
     final stopwatch = Stopwatch()..start();
     final sb = StringBuffer();
     for (var i = 0; i < 10000; i++) {

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -1,6 +1,6 @@
 library test_data;
 
-const List<dynamic> singleRow = const [
+const List<dynamic> singleRow = [
   1,
   'a',
   2,
@@ -14,9 +14,9 @@ const List<dynamic> singleRow = const [
 ];
 
 // see https://github.com/close2/csv/issues/5
-const List<List> testDataIssue5 = const [
-  const ['Alice', 'Austria', 1],
-  const ['Bob', ',Brazil', 2]
+const List<List> testDataIssue5 = [
+  ['Alice', 'Austria', 1],
+  ['Bob', ',Brazil', 2]
 ];
 const testCsvIssue5 = 'Alice,Austria,1\r\nBob,#,Brazil#,2';
 
@@ -42,12 +42,12 @@ const String csvSingleRowDotSingleQuot_endQuotDouble =
 const String csvSingleRowAaBbXy =
     '1aabbaXYaa2aabbaabbXYaabbc\ndXYaa3aae",faa4aag\',haa5.6';
 
-const List<List> multipleRows = const [singleRow, singleRow, singleRow];
+const List<List> multipleRows = [singleRow, singleRow, singleRow];
 
 const String csvSimpleStringsSingleRowComma = 'a,b';
-const List simpleStringsSingleRow = const ['a', 'b'];
+const List simpleStringsSingleRow = ['a', 'b'];
 
-const List singleRowAllText = const [
+const List singleRowAllText = [
   '1',
   'a',
   '2',
@@ -59,7 +59,7 @@ const List singleRowAllText = const [
   "g',h",
   '5.6'
 ];
-const List singleRowNoDouble = const [
+const List singleRowNoDouble = [
   1,
   'a',
   2,
@@ -72,12 +72,12 @@ const List singleRowNoDouble = const [
   '5.6'
 ];
 
-const List<List> multipleRowsAllText = const [
+const List<List> multipleRowsAllText = [
   singleRowAllText,
   singleRowAllText,
   singleRowAllText
 ];
-const List<List> multipleRowsNoDouble = const [
+const List<List> multipleRowsNoDouble = [
   singleRowNoDouble,
   singleRowNoDouble,
   singleRowNoDouble
@@ -95,20 +95,20 @@ const String csvComplex_part4 =
 const String csvComplex_ending1 = '...';
 const String csvComplex_ending2 = '...#...#';
 
-const List<String> csvComplex_parts = const [
+const List<String> csvComplex_parts = [
   csvComplex_part1,
   csvComplex_part2,
   csvComplex_part3,
   csvComplex_part4
 ];
-const List<String> csvComplex_parts_ending1 = const [
+const List<String> csvComplex_parts_ending1 = [
   csvComplex_part1,
   csvComplex_part2,
   csvComplex_part3,
   csvComplex_part4,
   csvComplex_ending1
 ];
-const List<String> csvComplex_parts_ending2 = const [
+const List<String> csvComplex_parts_ending2 = [
   csvComplex_part1,
   csvComplex_part2,
   csvComplex_part3,
@@ -131,26 +131,26 @@ const String csvComplexRows_ending2 = '$csvComplex_part1'
     '$csvComplex_part4'
     '$csvComplex_ending2';
 
-const List<List> complexRows = const [
-  const ['', 'a...*...#', '', 1.2, ''],
-  const ['1.2', '', '...#'],
-  const [''],
-  const ['', '']
+const List<List> complexRows = [
+  ['', 'a...*...#', '', 1.2, ''],
+  ['1.2', '', '...#'],
+  [''],
+  ['', '']
 ];
 
-const List<List> complexRows_ending1 = const [
-  const ['', 'a...*...#', '', 1.2, ''],
-  const ['1.2', '', '...#'],
-  const [''],
-  const ['', ''],
-  const ['...']
+const List<List> complexRows_ending1 = [
+  ['', 'a...*...#', '', 1.2, ''],
+  ['1.2', '', '...#'],
+  [''],
+  ['', ''],
+  ['...']
 ];
-const List<List> complexRows_ending2 = const [
-  const ['', 'a...*...#', '', 1.2, ''],
-  const ['1.2', '', '...#'],
-  const [''],
-  const ['', ''],
-  const ['']
+const List<List> complexRows_ending2 = [
+  ['', 'a...*...#', '', 1.2, ''],
+  ['1.2', '', '...#'],
+  [''],
+  ['', ''],
+  ['']
 ];
 
 // fieldDelimiter: ...*
@@ -160,21 +160,18 @@ const String csvComplex2_part1 = '..*.*...*#a..*';
 const String csvComplex2_part2 = '.*..*.';
 
 const String csvComplex2Rows = '$csvComplex2_part1$csvComplex2_part2';
-const List<String> csvComplex2_parts = const [
-  csvComplex2_part1,
-  csvComplex2_part2
-];
+const List<String> csvComplex2_parts = [csvComplex2_part1, csvComplex2_part2];
 
-const List<List> complexRows2 = const [
-  const ['.'],
-  const ['', '#a.'],
-  const ['..*.']
+const List<List> complexRows2 = [
+  ['.'],
+  ['', '#a.'],
+  ['..*.']
 ];
 
 // fieldDelimiter: ,
 // textDelimiter: .,a,b,__
 // eol: _xyz
-const List<String> csvComplex3_parts = const [
+const List<String> csvComplex3_parts = [
   '.,a,b,_',
   'xy',
   'z.,a,b,_',
@@ -186,13 +183,13 @@ const List<String> csvComplex3_parts = const [
 
 final csvComplex3Rows = csvComplex3_parts.join();
 
-const List<List> complexRows3 = const [
-  const ['.', 'a', 'b', ''],
-  const ['_xyz'],
-  const ['', '.', 'a', 'b', '_']
+const List<List> complexRows3 = [
+  ['.', 'a', 'b', ''],
+  ['_xyz'],
+  ['', '.', 'a', 'b', '_']
 ];
 
-const List<String> autodetectCsv_parts = const [
+const List<String> autodetectCsv_parts = [
   'ab',
   'c,2',
   ',\n"',
@@ -203,8 +200,8 @@ const List<String> autodetectCsv_parts = const [
 
 final String autodetectCsv = autodetectCsv_parts.join();
 
-const List<List> autodetectRows = const [
-  const ['abc', 2, ''],
-  const ['3,', "'\r"],
-  const ['!', "'"]
+const List<List> autodetectRows = [
+  ['abc', 2, ''],
+  ['3,', "'\r"],
+  ['!', "'"]
 ];


### PR DESCRIPTION
I am creating this pull request after updating dependencies to released version, so the suffix -nullsafety of the csv plugin can be removed and considered as release.
I have also removed all the unecessary keywords const and new.