### PR TITLE
fix: allow end of string as last character of file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
+# 5.0.2
+fix bug #61 "Unexpected Error: The text end delimiter (") for the last field is missing."  
+thanks https://github.com/liam7800
+
+Improve nullsafety code.
+
 # 5.0.1
-fix bug #26 "A value of type 'dynamic' can't be assigned to a variable of type 'String'."
+fix bug #26 "A value of type 'dynamic' can't be assigned to a variable of type 'String'."  
 thanks https://github.com/lil5
 
 # 5.0.0
@@ -10,11 +16,11 @@ Removing unnecessary const and new keywords
 Thanks to: https://github.com/arnaudelub
 
 # 5.0.0-nullsafety.0
-nullsafety
+nullsafety  
 Thanks to: https://github.com/darwingr
 
 # 4.1.0
-Add `returnString` option to work around a major performance bug.
+Add `returnString` option to work around a major performance bug.  
 Thanks: @boukeversteegh
 
 # 4.0.3

--- a/lib/csv.dart
+++ b/lib/csv.dart
@@ -8,6 +8,7 @@ import 'src/complex_converter.dart';
 import 'csv_settings_autodetection.dart';
 
 part 'csv_to_list_converter.dart';
+
 part 'list_to_csv_converter.dart';
 
 /// The RFC conform default value for field delimiter.

--- a/lib/csv_to_list_converter.dart
+++ b/lib/csv_to_list_converter.dart
@@ -45,10 +45,8 @@ class CsvToListConverter extends StreamTransformerBase<String, List>
       bool? shouldParseNumbers,
       bool? allowInvalid})
       : textDelimiter = textDelimiter,
-        textEndDelimiter =
-            textEndDelimiter ?? textDelimiter,
-        shouldParseNumbers =
-            shouldParseNumbers ?? true,
+        textEndDelimiter = textEndDelimiter ?? textDelimiter,
+        shouldParseNumbers = shouldParseNumbers ?? true,
         allowInvalid = allowInvalid ?? true;
 
   /// Verifies current settings.

--- a/lib/list_to_csv_converter.dart
+++ b/lib/list_to_csv_converter.dart
@@ -108,8 +108,7 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
       this.eol = defaultEol,
       this.delimitAllFields = defaultDelimitAllFields})
       : textDelimiter = textDelimiter,
-        textEndDelimiter =
-            textEndDelimiter ?? textDelimiter;
+        textEndDelimiter = textEndDelimiter ?? textDelimiter;
 
   /// Converts rows -- a [List] of [List]s into a csv String.
   ///
@@ -237,7 +236,9 @@ class ListToCsvConverter extends StreamTransformerBase<List, String>
           ..write(valString) // 5,3
           ..write(textEndDelimiter); // "
       } else {
-        sb..write(fieldDel)..write(valString);
+        sb
+          ..write(fieldDel)
+          ..write(valString);
       }
       fieldDel = fieldDelimiter;
       return sb;

--- a/lib/src/csv_argument_errors.dart
+++ b/lib/src/csv_argument_errors.dart
@@ -2,22 +2,26 @@ part of csv_parser;
 
 class EolNullError extends ArgumentError {
   static const String msg = 'The eol character must not be null';
+
   EolNullError() : super(msg);
 }
 
 class FieldDelimiterNullError extends ArgumentError {
   static const String msg = 'The field delimiter character must not be null';
+
   FieldDelimiterNullError() : super(msg);
 }
 
 class TextDelimiterNullError extends ArgumentError {
   static const String msg = 'The text delimiter character must not be null';
+
   TextDelimiterNullError() : super(msg);
 }
 
 class TextEndDelimiterNullError extends ArgumentError {
   static const String msg =
       'The text end delimiter character must not be null.';
+
   TextEndDelimiterNullError() : super(msg);
 }
 

--- a/lib/src/csv_parser.dart
+++ b/lib/src/csv_parser.dart
@@ -166,10 +166,10 @@ class CsvParser {
 
   /// Are we inside a quoted text/string ([_insideString] must be true as well
   /// if [_insideQuotedString] is true).
-  bool? _insideQuotedString;
+  bool _insideQuotedString = false;
 
   /// Did we just now parse a [textEndDelimiter]?
-  bool? _previousWasTextEndDelimiter;
+  bool _previousWasTextEndDelimiter = false;
 
   // Counters for multi-character matching:
 
@@ -224,8 +224,7 @@ class CsvParser {
         textEndDelimiter = _argValue(allowInvalid, textEndDelimiter, '"',
             userValue2: textDelimiter),
         eol = _argValue(allowInvalid, eol, '\r\n'),
-        shouldParseNumbers =
-            shouldParseNumbers ?? true,
+        shouldParseNumbers = shouldParseNumbers ?? true,
         allowInvalid = allowInvalid ?? true,
         _matchingFieldDelimiter = 0,
         _matchingTextDelimiter = 0,
@@ -290,15 +289,15 @@ class CsvParser {
   // See the implementation note at the start of this class.
   bool _match(String c, bool matching) {
     final onlyTextEndDelimiterMatches =
-        _insideQuotedString! && !_previousWasTextEndDelimiter!;
+        _insideQuotedString && !_previousWasTextEndDelimiter;
 
     // never look for a start text delimiter inside a quoted string.
     // (even if _previousWasTextEndDelimiter)
     final matchTextDelimiters =
-        !_insideQuotedString! && (!matching || _matchingTextDelimiter > 0);
+        !_insideQuotedString && (!matching || _matchingTextDelimiter > 0);
 
     final matchTextEndDelimiters =
-        _insideQuotedString! && (!matching || _matchingTextEndDelimiter > 0);
+        _insideQuotedString && (!matching || _matchingTextEndDelimiter > 0);
 
     final matchFieldDelimiters = !onlyTextEndDelimiterMatches &&
         (!matching || _matchingFieldDelimiter > 0);
@@ -395,7 +394,7 @@ class CsvParser {
     // We must be inside a quoted string, otherwise textEndDelimiter isn't
     // even considered.
 
-    if (_previousWasTextEndDelimiter!) {
+    if (_previousWasTextEndDelimiter) {
       // we have just read a textEndDelimiter
       // so this is the second textEndDelimiter → output textDelimiter
       _addTextToField(textEndDelimiter);
@@ -409,7 +408,7 @@ class CsvParser {
   ParsingResult _consumeEol() {
     _resetMatcher();
 
-    assert(_insideQuotedString == false || _previousWasTextEndDelimiter!);
+    assert(_insideQuotedString == false || _previousWasTextEndDelimiter);
 
     _insideString = false;
     _insideQuotedString = false;
@@ -426,7 +425,7 @@ class CsvParser {
     _resetMatcher();
 
     _insideString = false;
-    assert(_insideQuotedString == false || _previousWasTextEndDelimiter!);
+    assert(_insideQuotedString == false || _previousWasTextEndDelimiter);
     _insideQuotedString = false;
 
     var quoted = _previousWasTextEndDelimiter;
@@ -629,7 +628,7 @@ class CsvParser {
     if (!allowInvalid &&
         result.stopReason == ParsingStopReason.EndOfString &&
         fieldCompleteWhenEndOfString &&
-        _insideQuotedString!) {
+        (_insideQuotedString && !_previousWasTextEndDelimiter)) {
       throw InvalidCsvException(textEndDelimiter);
     }
     return result;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: csv
-version: 5.0.1
+version: 5.0.2
 description: |-
   A codec to transform between a string and a list of values.
 

--- a/test/csv_to_list_test.dart
+++ b/test/csv_to_list_test.dart
@@ -358,7 +358,7 @@ void main_converter() {
   });
 
   test(
-      'Doesn\'t throw an exception if allowInvalid and field Delimiter and '
+      "Doesn't throw an exception if allowInvalid and field Delimiter and "
       'text Delimiter are equal or either is null', () {
     expect(
         CsvToListConverter(fieldDelimiter: 'a', textDelimiter: 'a')
@@ -406,7 +406,7 @@ void main_converter() {
         throwsArgumentError);
   });
 
-  test('Doesn\'t throw an exception if allowInvalid and eol is null', () {
+  test("Doesn't throw an exception if allowInvalid and eol is null", () {
     expect(
         CsvToListConverter(eol: null).convert('a'),
         equals([
@@ -521,5 +521,16 @@ void main_converter() {
           ),
           [singleRow]);
     });
+  });
+
+  test('Issue61 No EOL and quote as last character', () {
+    var input = '"abc","def"';
+    var csv = CsvToListConverter(textDelimiter: '"', allowInvalid: false)
+        .convert(input);
+    expect(
+        csv,
+        equals([
+          ['abc', 'def']
+        ]));
   });
 }


### PR DESCRIPTION
Fixes issue #61

If `allowInvalid` is set to false, we threw an exception if the last character of the CSV was a closing text-delimiter.

We didn't recognize this, as there is the possibility, that another text-delimiter "uncloses" a text-field.  This is of course not possible if there are no characters left.